### PR TITLE
fix Rscript shebang

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -95,7 +95,7 @@ rule validate_putatEVEs:
         tsv="results/{asm}-validatEVEs.tsv",
         pdf="results/{asm}-validatEVEs.pdf"
     shell:
-        "{scripts}/validate.R {input} {output.tsv} {output.pdf}"
+        "Rscript --vanilla {scripts}/validate.R {input} {output.tsv} {output.pdf}"
 
 rule extract_validatEVEs:
     input:

--- a/workflow/scripts/validate.R
+++ b/workflow/scripts/validate.R
@@ -1,4 +1,3 @@
-#!Rscript --vanilla
 # command line interface ------------------------------------------------------#
 library(docopt)
 'Validate putatEVEs based on retroblast hits


### PR DESCRIPTION
Shebang does not work for me. Seems to be some issues with Snakemake. Fix that work for me was using `Rscript -vanilla` from within the Snakemake file instead of within the validate.R file. Fixes #7 